### PR TITLE
No Spread Attributes with Class - SP-8909

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Each rule has emojis denoting:
 | [no-route-action](./docs/rule/no-route-action.md)                                                         | ✅  |     |     |     |
 | [no-scope-outside-table-headings](./docs/rule/no-scope-outside-table-headings.md)                         | ✅  |     | ⌨️  |     |
 | [no-shadowed-elements](./docs/rule/no-shadowed-elements.md)                                               | ✅  |     |     |     |
+| [no-splattributes-with-class](./docs/rule/no-splattributes-with-class.md)                                 |     |     |     |     |
 | [no-this-in-template-only-components](./docs/rule/no-this-in-template-only-components.md)                 |     |     |     | 🔧  |
 | [no-trailing-spaces](./docs/rule/no-trailing-spaces.md)                                                   |     | 💅  |     | 🔧  |
 | [no-triple-curlies](./docs/rule/no-triple-curlies.md)                                                     | ✅  |     |     |     |

--- a/docs/rule/no-splattributes-with-class.md
+++ b/docs/rule/no-splattributes-with-class.md
@@ -37,6 +37,7 @@ This rule **allows** the following:
 When using `...attributes`, any classes passed from the parent component will be automatically merged with the component's own classes. Adding a `class` attribute alongside `...attributes` can lead to confusion about which classes take precedence and may result in unexpected styling behavior.
 
 For example:
+
 ```hbs
 {{!-- Parent component --}}
 <MyComponent class="parent-class" />
@@ -48,6 +49,7 @@ For example:
 ```
 
 Instead, you should either:
+
 1. Use `...attributes` alone to allow class merging from the parent
 2. Use `class` alone if you want to enforce specific classes
 

--- a/docs/rule/no-splattributes-with-class.md
+++ b/docs/rule/no-splattributes-with-class.md
@@ -1,0 +1,56 @@
+# no-splattributes-with-class
+
+This rule enforces that when using `...attributes` (spread attributes), you should not also use a `class` attribute. The `...attributes` syntax is used to forward HTML attributes from a parent component to a child component, and it already handles class merging automatically.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<div ...attributes class="foo">
+  content
+</div>
+```
+
+```hbs
+<div class="foo" ...attributes>
+  content
+</div>
+```
+
+This rule **allows** the following:
+
+```hbs
+<div ...attributes>
+  content
+</div>
+```
+
+```hbs
+<div class="foo">
+  content
+</div>
+```
+
+## Why?
+
+When using `...attributes`, any classes passed from the parent component will be automatically merged with the component's own classes. Adding a `class` attribute alongside `...attributes` can lead to confusion about which classes take precedence and may result in unexpected styling behavior.
+
+For example:
+```hbs
+{{!-- Parent component --}}
+<MyComponent class="parent-class" />
+
+{{!-- MyComponent template --}}
+<div ...attributes class="child-class">
+  {{!-- This is confusing: which class takes precedence? --}}
+</div>
+```
+
+Instead, you should either:
+1. Use `...attributes` alone to allow class merging from the parent
+2. Use `class` alone if you want to enforce specific classes
+
+## References
+
+* [Splattributes](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/#toc_html-attributes) in the Ember.js guides

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -79,6 +79,7 @@ import norestrictedinvocations from './no-restricted-invocations.js';
 import norouteaction from './no-route-action.js';
 import noscopeoutsidetableheadings from './no-scope-outside-table-headings.js';
 import noshadowedelements from './no-shadowed-elements.js';
+import nosplattributeswithclass from './no-splattributes-with-class.js';
 import nothisintemplateonlycomponents from './no-this-in-template-only-components.js';
 import notrailingspaces from './no-trailing-spaces.js';
 import notriplecurlies from './no-triple-curlies.js';
@@ -202,6 +203,7 @@ export default {
   'no-route-action': norouteaction,
   'no-scope-outside-table-headings': noscopeoutsidetableheadings,
   'no-shadowed-elements': noshadowedelements,
+  'no-splattributes-with-class': nosplattributeswithclass,
   'no-this-in-template-only-components': nothisintemplateonlycomponents,
   'no-trailing-spaces': notrailingspaces,
   'no-triple-curlies': notriplecurlies,

--- a/lib/rules/no-splattributes-with-class.js
+++ b/lib/rules/no-splattributes-with-class.js
@@ -1,0 +1,22 @@
+import Rule from './_base.js';
+
+export const ERROR_MESSAGE =
+  'Using `...attributes` with `class` attribute is not allowed. Use `...attributes` alone to allow class merging.';
+
+export default class NoSplattributesWithClass extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        const hasSplattributes = node.attributes.some((attr) => attr.name === '...attributes');
+        const hasClass = node.attributes.some((attr) => attr.name === 'class');
+
+        if (hasSplattributes && hasClass) {
+          this.log({
+            message: ERROR_MESSAGE,
+            node: node.attributes.find((attr) => attr.name === 'class'),
+          });
+        }
+      },
+    };
+  }
+}

--- a/test/unit/rules/no-splattributes-with-class-test.js
+++ b/test/unit/rules/no-splattributes-with-class-test.js
@@ -1,0 +1,55 @@
+import { ERROR_MESSAGE } from '../../../lib/rules/no-splattributes-with-class.js';
+import generateRuleTests from '../../helpers/rule-test-harness.js';
+
+generateRuleTests({
+  name: 'no-splattributes-with-class',
+
+  config: true,
+
+  good: [
+    '<div ...attributes>content</div>',
+    '<div class="foo">content</div>',
+    '<div class="foo bar">content</div>',
+    '<div class={{foo}}>content</div>',
+    '<div class="foo {{bar}}">content</div>',
+  ],
+
+  bad: [
+    {
+      template: '<div ...attributes class="foo">content</div>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 19,
+        source: 'class="foo"',
+      },
+    },
+    {
+      template: '<div class="foo" ...attributes>content</div>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 5,
+        source: 'class="foo"',
+      },
+    },
+    {
+      template: '<div ...attributes class={{foo}}>content</div>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 19,
+        source: 'class={{foo}}',
+      },
+    },
+    {
+      template: '<div class="foo" ...attributes class="bar">content</div>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 5,
+        source: 'class="foo"',
+      },
+    },
+  ],
+});


### PR DESCRIPTION
This rule enforces that when using `...attributes` (spread attributes), you should not also use a `class` attribute. The `...attributes` syntax is used to forward HTML attributes from a parent component to a child component, and it already handles class merging automatically.

Read PR description here: https://github.com/ember-template-lint/ember-template-lint/pull/3196